### PR TITLE
Add message-id type definition

### DIFF
--- a/types/libp2p-gossipsub/index.d.ts
+++ b/types/libp2p-gossipsub/index.d.ts
@@ -12,6 +12,7 @@ declare module 'libp2p-gossipsub' {
     }
 
     export interface IGossipMessage {
+        ["message-id"]?: string;
         from: Buffer | string;
         data: Buffer;
         seqno: Buffer;

--- a/types/libp2p-gossipsub/index.d.ts
+++ b/types/libp2p-gossipsub/index.d.ts
@@ -39,6 +39,7 @@ declare module 'libp2p-gossipsub' {
         validate(message: IGossipMessage): Promise<boolean>;
         _emitMessage(topics: string[], message: IGossipMessage): void;
         getTopics(): string[];
+        _publish(messages: IGossipMessage[]): void;
     }
 
     export default GossipSub;


### PR DESCRIPTION
Spec PR: https://github.com/ethereum/eth2.0-specs/pull/1538/files
```
The message-id of a gossipsub message MUST be:

   `message-id: base64(SHA256(message.data))`
```